### PR TITLE
Performance Debugging

### DIFF
--- a/airspy_m0/airspy_m0.c
+++ b/airspy_m0/airspy_m0.c
@@ -213,9 +213,19 @@ int main(void)
 
   usb_run(&usb_device);
 
+#ifdef PERF_DEBUG
+  GPIO_DIR(PORT_EN_M0_ACTIVE) |= PIN_EN_M0_ACTIVE; // Set M0_ACTIVE pin as output.
+  while(true)
+  {
+    GPIO_CLR(PORT_EN_M0_ACTIVE) = PIN_EN_M0_ACTIVE; // Clear M0_ACTIVE pin low before we go to sleep
+    signal_wfe();
+    GPIO_SET(PORT_EN_M0_ACTIVE) = PIN_EN_M0_ACTIVE; // Set M0_ACTIVE pin high as we awake
+#else
   while(true)
   {
     signal_wfe();
+#endif
+
 #ifdef USE_PACKING
 	switch(get_usb_buffer_offset())
 	{

--- a/airspy_m4/airspy_m4.c
+++ b/airspy_m4/airspy_m4.c
@@ -431,10 +431,19 @@ int main(void)
   usb_bulk_buffer_offset_m4 = &usb_bulk_buffer_offset_uint32_m4;
 #endif
 
-  while(true)
+#ifdef PERF_DEBUG
+  GPIO_DIR(PORT_EN_M4_ACTIVE) |= PIN_EN_M4_ACTIVE; // Set M4_ACTIVE pin as output.
+  while(true) 
+  {
+    GPIO_CLR(PORT_EN_M4_ACTIVE) = PIN_EN_M4_ACTIVE; // Clear M4_ACTIVE pin low before we go to sleep
+    signal_wfe();
+    GPIO_SET(PORT_EN_M4_ACTIVE) = PIN_EN_M4_ACTIVE; // Set M4_ACTIVE pin high as we awake
+#else
+  while(true) 
   {
     signal_wfe();
-  
+#endif 
+
 #ifdef USE_PACKING
   /* Thanks to Pierre HB9FUF for the initial packing proof-of-concept */
   /* The following expands the PoC to use 4 buffers with an improved packing routine above */

--- a/common/airspy_core.h
+++ b/common/airspy_core.h
@@ -53,6 +53,12 @@ extern "C"
 #define PIN_EN_BIAST    (BIT13) /* GPIO1[13] on P2_13 */
 #define PORT_EN_BIAST   (GPIO1)
 
+#define PIN_EN_M4_ACTIVE  (BIT2) /* GPIO0[2] on P1_15 */
+#define PORT_EN_M4_ACTIVE (GPIO0)
+
+#define PIN_EN_M0_ACTIVE  (BIT9) /* GPIO1[9] on P1_6 */
+#define PORT_EN_M0_ACTIVE (GPIO1)
+
 /* GPIO Input PinMux */
 #define SCU_PINMUX_BOOT0    (P1_1)  /* GPIO0[8] on P1_1 */
 #define SCU_PINMUX_BOOT1    (P1_2)  /* GPIO0[9] on P1_2 */


### PR DESCRIPTION
Set GPIO pin(s) high/low when processor cores M4/M0 enter/leave
signal_wfe()

This allows an oscilloscope to be attached to the Airspy headers, and
the user can see how long the processing takes after each interrupt. The
user can then establish if the processors have enough "grunt" to keep up
with the processing of the incomming ADC sample stream.

To enable the debugging, add the line #define PERF_DEBUG 1 to the source
code.

Currently setup so that :
M4 = GPIO0[2] on P1_15 = Plug1 pin 1
M0 = GPIO1[9] on P1_6 = Plug2 pin 1
