### PR TITLE
Implement M4->M0 message queue

### DIFF
--- a/airspy_m0/airspy_m0.c
+++ b/airspy_m0/airspy_m0.c
@@ -55,9 +55,9 @@
 extern uint32_t cm4_data_share; /* defined in linker script */
 extern uint32_t cm0_data_share; /* defined in linker script */
 
-volatile unsigned int phase = 0;
+//volatile unsigned int phase = 0;
 
-volatile uint32_t *usb_bulk_buffer_offset = (&cm4_data_share);
+volatile airspy_m0_queue_t *m0_queue = (&cm4_data_share);
 volatile uint32_t *start_adchs = (&cm0_data_share);
 
 #define START_ADCHS_CMD  (1)
@@ -66,7 +66,7 @@ volatile uint32_t *start_adchs = (&cm0_data_share);
 volatile uint32_t *set_samplerate = ((&cm0_data_share)+1);
 #define SET_SAMPLERATE_CMD  (1)
 
-#define get_usb_buffer_offset() (usb_bulk_buffer_offset[0])
+//#define get_usb_buffer_offset() (usb_bulk_buffer_offset[0])
 
 #define MASTER_TXEV_FLAG  ((uint32_t *) 0x40043130)
 #define MASTER_TXEV_QUIT()  { *MASTER_TXEV_FLAG = 0x0; }
@@ -151,7 +151,7 @@ void ADCHS_start(uint32_t conf_num)
   r820t_init(&r820t_conf_rw, airspy_m0_conf[conf_num].r820t_if_freq);
   r820t_set_if_bandwidth(&r820t_conf_rw, airspy_m0_conf[conf_num].r820t_if_bw);
 
-  phase = 1;
+  //phase = 1;
 }
 
 void ADCHS_stop(uint32_t conf_num)
@@ -215,6 +215,31 @@ int main(void)
 
   while(true)
   {
+    uint32_t q_word, q_tail, buffer_off, buffer_len ;
+    signal_wfe();
+    // While there is/are new commands coming from M4
+    while ((q_tail = m0_queue->q_tail) != m0_queue->q_head)
+    {
+      // get the data from the queue
+      q_word = m0_queue->q[q_tail & M0_QUEUE_MASK];
+
+      // update the queue tail to free the entry we've just removed
+      m0_queue->q_tail = ((q_tail + 1) & M0_QUEUE_MASK);
+
+      // separate the buffer offset and length that M4 want's us to transmit on USB 
+      buffer_len = (q_word & 0x0000FFFF); 
+      buffer_off = (q_word >> 16);
+
+      // perform a sanity check on the values : (len != 0) && (offset+len < size_of_buffer)
+      if ( (buffer_len) && ((buffer_off + buffer_len) <= 32768))
+      { // schedule the requested data for transmission
+			  usb_transfer_schedule_block(&usb_endpoint_bulk_in, &usb_bulk_buffer[buffer_off], buffer_len, NULL, NULL);
+      }
+    }
+  }
+/*
+  while(true)
+  {
     signal_wfe();
 #ifdef USE_PACKING
 	switch(get_usb_buffer_offset())
@@ -264,4 +289,5 @@ int main(void)
     }
 #endif	
   }
+*/
 }

--- a/airspy_m0/airspy_m0.c
+++ b/airspy_m0/airspy_m0.c
@@ -55,9 +55,7 @@
 extern uint32_t cm4_data_share; /* defined in linker script */
 extern uint32_t cm0_data_share; /* defined in linker script */
 
-//volatile unsigned int phase = 0;
-
-volatile airspy_m0_queue_t *m0_queue = (&cm4_data_share);
+volatile airspy_m0_queue_t* m0_queue = (airspy_m0_queue_t*) (&cm4_data_share);
 volatile uint32_t *start_adchs = (&cm0_data_share);
 
 #define START_ADCHS_CMD  (1)
@@ -66,12 +64,12 @@ volatile uint32_t *start_adchs = (&cm0_data_share);
 volatile uint32_t *set_samplerate = ((&cm0_data_share)+1);
 #define SET_SAMPLERATE_CMD  (1)
 
-//#define get_usb_buffer_offset() (usb_bulk_buffer_offset[0])
-
 #define MASTER_TXEV_FLAG  ((uint32_t *) 0x40043130)
 #define MASTER_TXEV_QUIT()  { *MASTER_TXEV_FLAG = 0x0; }
 
-uint8_t* const usb_bulk_buffer = (uint8_t*)0x20004000;
+#define USB_BULK_BUFFER_START     (0x20008000)
+#define USB_BULK_BUFFER_SIZE_BYTE (16384)
+uint8_t* const usb_bulk_buffer = (uint8_t*) USB_BULK_BUFFER_START;
 
 uint8_t spiflash_buffer[W25Q80BV_PAGE_LEN];
 char version_string[] = VERSION_STRING " " AIRSPY_FW_GIT_TAG " " AIRSPY_FW_BUILD_DATE;
@@ -150,8 +148,6 @@ void ADCHS_start(uint32_t conf_num)
 
   r820t_init(&r820t_conf_rw, airspy_m0_conf[conf_num].r820t_if_freq);
   r820t_set_if_bandwidth(&r820t_conf_rw, airspy_m0_conf[conf_num].r820t_if_bw);
-
-  //phase = 1;
 }
 
 void ADCHS_stop(uint32_t conf_num)
@@ -231,9 +227,9 @@ int main(void)
       buffer_off = (q_word >> 16);
 
       // perform a sanity check on the values : (len != 0) && (offset+len < size_of_buffer)
-      if ( (buffer_len) && ((buffer_off + buffer_len) <= 32768))
+      if ( (buffer_len) && ((buffer_off + buffer_len) <= USB_BULK_BUFFER_SIZE_BYTE))
       { // schedule the requested data for transmission
-			  usb_transfer_schedule_block(&usb_endpoint_bulk_in, &usb_bulk_buffer[buffer_off], buffer_len, NULL, NULL);
+        usb_transfer_schedule_block(&usb_endpoint_bulk_in, &usb_bulk_buffer[buffer_off], buffer_len, NULL, NULL);
       }
     }
   }

--- a/airspy_m4/adchs.c
+++ b/airspy_m4/adchs.c
@@ -97,17 +97,17 @@ void ADCHS_DMA_init(uint32_t dest_addr)
                                (0x1 << 25)  |
                                (0x0 << 26)  |
                                (0x1 << 27)  |
-#ifdef USE_PACKING							   
+//#ifdef USE_PACKING							   
                                (0x1UL << 31);
-#else							 
-                               (0x0UL << 31);
-#endif							  
+//#else							 
+//                             (0x0UL << 31);
+//#endif							  
   }
 
-#ifndef USE_PACKING
-  adchs_dma_lli[(ADCHS_DMA_NUM_LLI/2)-1].control |= (0x1UL << 31);
-  adchs_dma_lli[i-1].control |= (0x1UL << 31);
-#endif  
+//#ifndef USE_PACKING
+//  adchs_dma_lli[(ADCHS_DMA_NUM_LLI/2)-1].control |= (0x1UL << 31);
+//  adchs_dma_lli[i-1].control |= (0x1UL << 31);
+//#endif  
 
   LPC_GPDMA->C0SRCADDR = adchs_dma_lli[0].src_addr;
   LPC_GPDMA->C0DESTADDR = adchs_dma_lli[0].dst_addr;

--- a/airspy_m4/adchs.h
+++ b/airspy_m4/adchs.h
@@ -38,14 +38,17 @@ void ADCHS_stop(uint32_t conf_num);
 void adchs_isr(void);
 void dma_isr(void);
 
-#define USB_BULK_BUFFER_START (0x20004000)
+#define USB_BULK_BUFFER_START     (0x20008000)
+#define USB_BULK_BUFFER_SIZE_BYTE (16384)
+#define USB_BULK_BUFFER_SIZE_MASK (USB_BULK_BUFFER_SIZE_BYTE-1)
 
-#define ADCHS_DATA_BUFFER_SIZE_BYTE (32768)
-#define ADCHS_DATA_BUFFER (USB_BULK_BUFFER_START)
+#define ADCHS_DATA_BUFFER           (0x20004000)
+#define ADCHS_DATA_BUFFER_SIZE_BYTE (16384)
+#define ADCHS_DATA_BUFFER_SIZE_MASK (ADCHS_DATA_BUFFER_SIZE_BYTE-1)
 
-#define ADCHS_DMA_NUM_LLI (4) /* Corresponds to number of transfer */
-#define ADCHS_DMA_NB_BUFFER ( (ADCHS_DMA_NUM_LLI/2) )
-#define ADCHS_DATA_TRANSFER_SIZE_BYTE ( ((ADCHS_DATA_BUFFER_SIZE_BYTE/ADCHS_DMA_NUM_LLI)*2) ) /* Size of Each Transfer in Byte */
+#define ADCHS_DMA_NUM_LLI             (2)                                                 // Corresponds to number of transfer
+#define ADCHS_DMA_NB_BUFFER           (ADCHS_DMA_NUM_LLI)
+#define ADCHS_DATA_TRANSFER_SIZE_BYTE (ADCHS_DATA_BUFFER_SIZE_BYTE / ADCHS_DMA_NB_BUFFER) // Size of Each Transfer in Bytes
 
 #define ADCHS_DMA_WRITE 7
 #define ADCHS_DMA_READ  8

--- a/airspy_m4/airspy_m4.c
+++ b/airspy_m4/airspy_m4.c
@@ -71,11 +71,11 @@ volatile uint32_t *usb_bulk_buffer_offset_m4;
 volatile unsigned int phase = 0;
 #endif
 */
-#define USB_BULK_BUFFER_SIZE_BYTE   (32768)
-#define USB_BULK_BUFFER_MASK        (USB_BULK_BUFFER_SIZE_BYTE - 1)
 
-volatile uint32_t usb_bulk_buffer_offset_isr_m4  = 0;
-volatile uint32_t usb_bulk_buffer_offset_main_m4 = 0;
+volatile uint32_t adchs_dma_buffer_offset_isr_m4  = 0;
+volatile uint32_t adchs_dma_buffer_offset_main_m4 = 0;
+volatile uint32_t usb_dma_buffer_length_main_m4 = 0;
+volatile uint32_t usb_dma_buffer_offset_main_m4 = 0;
 
 #define SLAVE_TXEV_FLAG ((uint32_t *) 0x40043400)
 #define SLAVE_TXEV_QUIT() { *SLAVE_TXEV_FLAG = 0x0; }
@@ -89,7 +89,8 @@ volatile int adchs_started = 0;
 
 //volatile uint32_t *usb_bulk_buffer_offset = &cm4_data_share;
 volatile airspy_m0_queue_t *m0_queue = (void *) (&cm4_data_share);
-uint8_t* const usb_bulk_buffer = (uint8_t*)USB_BULK_BUFFER_START;
+uint8_t* const usb_bulk_buffer = (uint8_t*) USB_BULK_BUFFER_START;
+uint8_t* const adchs_dma_buffer = (uint8_t*) ADCHS_DATA_BUFFER;
 
 volatile uint32_t *start_adchs = (&cm0_data_share);
 #define START_ADCHS_CMD  (1)
@@ -102,6 +103,15 @@ volatile uint32_t *set_samplerate = ((&cm0_data_share)+1);
 #define CONF_MASK ((1 << AIRSPY_SAMPLERATE_CMD_SHIFT_BIT)-1)
 
 volatile int first_start = 0;
+
+#define AIRSPY_FORMAT_MAX (2)
+typedef enum
+{
+	AIRSPY_FORMAT_PACK16       = 0,
+	AIRSPY_FORMAT_PACK12       = 1,
+	AIRSPY_FORMAT_PACK8        = AIRSPY_FORMAT_MAX
+} airspy_format_t;
+volatile airspy_format_t airspy_format = AIRSPY_FORMAT_PACK16;
 
 /*
 uint32_t nb_cycles[5] = { 0 };
@@ -127,32 +137,238 @@ uint32_t data_counter = 0;
 
   t_stats_adchs stat_adchs = { 0 };
 #endif
-
-#ifdef USE_PACKING
-__attribute__ ((always_inline)) static void pack(uint16_t* input, uint32_t* output, uint32_t length)
-{
+//
+// Packing Works @40MSPS with CPU Clk = 140Mhz : USB Bandwidth 20MBytes/sec
+// USB Bandwidth limits output to 20MBytse/sec = 20MSPS
+//
+__attribute__ ((always_inline)) static uint32_t pack16(uint8_t* input, uint8_t* output, uint32_t length) {
   uint32_t i;
+  uint32_t* pIn  = (uint32_t*) input;
+  uint32_t* pOut = (uint32_t*) output;
+  uint32_t  iLen = length >> 4;
     
-  for (i = 0; i < length; i += 8)
-  {    
-    register uint32_t t2, t5;
-    
-    t2 = input[i+2];      
-        
-    output[0] = ((uint32_t)(input[i] << 20)) | ((uint32_t)(input[i+1] << 8)) | (t2 >> 4);    
-    t5 = input[i+5];
-    output[1] = ((uint32_t)(t2&0xf) << 28)| ((uint32_t)input[i+3] << 16) | (input[i+4] << 4) | (t5 >> 8);
-    output[2] = ((uint32_t)(t5 & 0xff) << 24) | ((uint32_t)input[i+6]<<12) | ((uint32_t)input[i+7]);
-
-    output += 3;
+  for (i = 0; i < iLen; i++) {
+    *pOut++ = *pIn++; // 0bbb0aaa
+    *pOut++ = *pIn++; // 0ddd0ccc
+    *pOut++ = *pIn++; // 0fff0eee
+    *pOut++ = *pIn++; // 0hhh0ggg
   }
-}
-#endif
 
+  return (iLen << 4);
+}
+//
+// Packing Works @24MSPS with CPU Clk = 140Mhz : USB Bandwidth 18MBytes/sec
+// USB Bandwidth limits output to 20MBytse/sec = 26.666MSPS
+//
+__attribute__ ((always_inline)) static uint32_t pack12(uint8_t* input, uint8_t* output, uint32_t length) {
+  uint32_t i;
+  uint32_t* pIn  = (uint32_t*) input;
+  uint32_t* pOut = (uint32_t*) output;
+  uint32_t  iLen = length >> 5;
+    
+  for (i = 0; i < iLen; i++) {    
+    register uint32_t t0, t1, t2, t3, q0, q1, q2;
+    
+    t0 = *pIn++; // t0 = 0bbb0aaa
+    t1 = *pIn++; // t1 = 0ddd0ccc
+    t2 = *pIn++; // t2 = 0fff0eee
+    t3 = *pIn++; // t3 = 0hhh0ggg
+
+    q0 = ((t1 << 24) & 0xFF000000) | ((t0 >>  4) & 0x00FFF000) |  (t0        & 0x00000FFF);                            // q0 = ccbbbaaa
+    q1 = ((t2 << 12) & 0xF0000000) | ((t2 << 16) & 0x0FFF0000) | ((t1 >> 12) & 0x0000FFF0) | ((t1 >> 4) & 0x0000000F); // q1 = feeedddc
+    q2 = ((t3 <<  4) & 0xFFF00000) | ((t3 <<  8) & 0x000FFF00) | ((t2 >> 20) & 0x000000FF);                            // q2 = hhhgggff       
+
+    *pOut++ = q0; // ccbbbaaa
+    *pOut++ = q1; // feeedddc
+    *pOut++ = q2; // hhhgggff
+
+    t0 = *pIn++; // t0 = 0bbb0aaa
+    t1 = *pIn++; // t1 = 0ddd0ccc
+    t2 = *pIn++; // t2 = 0fff0eee
+    t3 = *pIn++; // t3 = 0hhh0ggg
+
+    q0 = ((t1 << 24) & 0xFF000000) | ((t0 >>  4) & 0x00FFF000) |  (t0        & 0x00000FFF);                            // q0 = ccbbbaaa
+    q1 = ((t2 << 12) & 0xF0000000) | ((t2 << 16) & 0x0FFF0000) | ((t1 >> 12) & 0x0000FFF0) | ((t1 >> 4) & 0x0000000F); // q1 = feeedddc
+    q2 = ((t3 <<  4) & 0xFFF00000) | ((t3 <<  8) & 0x000FFF00) | ((t2 >> 20) & 0x000000FF);                            // q2 = hhhgggff       
+
+    *pOut++ = q0; // ccbbbaaa
+    *pOut++ = q1; // feeedddc
+    *pOut++ = q2; // hhhgggff
+
+  }
+  return (iLen * 24);
+}
+//
+// Packing Works @32MSPS with CPU Clk = 140Mhz : USB Bandwidth 16MBytes/sec
+// Packing Works @40MSPS with CPU Clk = 160Mhz : USB Bandwidth 20MBytes/sec
+//
+__attribute__ ((always_inline)) static uint32_t pack8(uint8_t* input, uint8_t* output, uint32_t length) {
+  uint32_t i;
+  uint32_t* pIn  = (uint32_t*) input;
+  uint32_t* pOut = (uint32_t*) output;
+  uint32_t  iLen = length >> 5;
+
+  for (i = 0; i < iLen; i++) {    
+    register uint32_t t0, t1, t2, t3, tmp, q0, q1;
+       
+    t0 = *pIn++; // t0 = 0bbb0aaa
+    t1 = *pIn++; // t1 = 0ddd0ccc
+    t2 = *pIn++; // t2 = 0fff0eee
+    t3 = *pIn++; // t3 = 0hhh0ggg
+
+    q0  = 0xFF & (t0  >>  4); // q0  = 000000aa
+    tmp = 0xFF & (t0  >> 20); // tmp = 000000bb
+    q0  = q0   | (tmp <<  8); // q0  = 0000bbaa
+    tmp = 0xFF & (t1  >>  4); // tmp = 000000cc
+    q0  = q0   | (tmp << 16); // q0  = 00ccbbaa
+    tmp = 0xFF & (t1  >> 20); // tmp = 000000dd
+    q0  = q0   | (tmp << 24); // q0  = ddccbbaa
+  
+    q1  = 0xFF & (t2  >>  4); // q1  = 000000ee
+    tmp = 0xFF & (t2  >> 20); // tmp = 000000ff
+    q1  = q1   | (tmp <<  8); // q1  = 0000ffee
+    tmp = 0xFF & (t3  >>  4); // tmp = 000000gg
+    q1  = q1   | (tmp << 16); // q1  = 00ggffee
+    tmp = 0xFF & (t3  >> 20); // tmp = 000000hh
+    q1  = q1   | (tmp << 24); // q1  = hhggffee
+
+    *pOut++ = q0; // ddccbbaa
+    *pOut++ = q1; // hhggffee
+       
+    t0 = *pIn++; // t0 = 0bbb0aaa
+    t1 = *pIn++; // t1 = 0ddd0ccc
+    t2 = *pIn++; // t2 = 0fff0eee
+    t3 = *pIn++; // t3 = 0hhh0ggg
+
+    q0  = 0xFF & (t0  >>  4); // q0  = 000000aa
+    tmp = 0xFF & (t0  >> 20); // tmp = 000000bb
+    q0  = q0   | (tmp <<  8); // q0  = 0000bbaa
+    tmp = 0xFF & (t1  >>  4); // tmp = 000000cc
+    q0  = q0   | (tmp << 16); // q0  = 00ccbbaa
+    tmp = 0xFF & (t1  >> 20); // tmp = 000000dd
+    q0  = q0   | (tmp << 24); // q0  = ddccbbaa
+  
+    q1  = 0xFF & (t2  >>  4); // q1  = 000000ee
+    tmp = 0xFF & (t2  >> 20); // tmp = 000000ff
+    q1  = q1   | (tmp <<  8); // q1  = 0000ffee
+    tmp = 0xFF & (t3  >>  4); // tmp = 000000gg
+    q1  = q1   | (tmp << 16); // q1  = 00ggffee
+    tmp = 0xFF & (t3  >> 20); // tmp = 000000hh
+    q1  = q1   | (tmp << 24); // q1  = hhggffee
+
+    *pOut++ = q0; // ddccbbaa
+    *pOut++ = q1; // hhggffee
+  }
+  return (iLen << 4);
+}
+/*
+//
+__attribute__ ((always_inline)) static uint32_t pack16(uint8_t* input, uint8_t* output, uint32_t length) {
+  register uint32_t* n4 asm("r0") = (uint32_t*) input;
+  register uint32_t* n5 asm("r1") = (uint32_t*) output;
+  register uint32_t  n6 asm("r2") = length;
+  register uint32_t  n7 asm("r8");
+  asm volatile (
+       "lsr       %2,%2,#4\n\t"         //r2 = length >> 4 ; copy 16 bytes / pack 8 samples per loop 
+       "mov       r8,%2\n\t"            //r8 = iLen
+       "1:\n\t"
+       "ldmia.w   %0,{r3,r4,r5,r6}\n\t" //r3 = 0bbb0aaa, r4 = 0ddd0ccc, r5 = 0fff0eee, r6 = 0hhh0ggg
+       "add       %0,%0,#16\n\t"
+       "stmia.w   %1,{r3,r4,r5,r6}\n\t"
+       "add       %1,%1,#16\n\t"
+
+       "subs      %2,%2,#1\n\t"
+       "bne       1b\n\t"
+       : "+r" (n4), "+r" (n5), "+r" (n6), "+r" (n7) :: "r3", "r4", "r5", "r6", "cc", "memory");
+
+  return (n7 << 4);
+}
+//
+__attribute__ ((always_inline)) static uint32_t pack12(uint8_t* input, uint8_t* output, uint32_t length) {
+  register uint32_t* n4 asm("r0") = (uint32_t*) input;
+  register uint32_t* n5 asm("r1") = (uint32_t*) output;
+  register uint32_t  n6 asm("r2") = length;
+  register uint32_t  n7 asm("r8");
+  asm volatile (
+       "lsr       %2,%2,#4\n\t"          //r2 = nLen >> 4 ; copy 16 bytes / pack 8 samples per loop
+       "mov       r8,%2\n\t"             //r8 = iLen
+       "1:\n\t"
+       "ldmia.w   %0,{r3,r4,r5,r6}\n\t"  //r3 = 0bbb0aaa, r4 = 0ddd0ccc, r5 = 0fff0eee, r6 = 0hhh0ggg
+       "add       %0,%0,#16\n\t"
+
+       "lsr       r7,r3,#4\n\t"          //r7 = 00bbb0aa
+       "bfi       r3,r7,#12,#12\n\t"     //r3 = 00bbbaaa
+       "orr       r3,r3,r4,lsl #24\n\t"  //r3 = ccbbbaaa
+
+       "lsr       r4,r4,#8\n\t"          //r4 = 000ddd0c
+       "lsr       r7,r4,#4\n\t"          //r7 = 0000ddd0
+       "bfi       r4,r7,#4,#12\n\t"      //r4 = 0000dddc
+       "orr       r4,r4,r5,lsr #16\n\t"  //r4 = 0eeedddc
+       "ror       r5,r5,#20\n\t"         //r5 = f0eee0ff
+       "bfi       r4,r5,#28,#4\n\t"      //r4 = feeedddc
+ 
+       "ror       r6,r6,#24\n\t"         //r6 = hh0ggg0h
+       "bfi       r5,r6,#8,#12\n\t"      //r5 = 000gggff
+       "ror       r6,r6,#4\n\t"          //r6 = hhh0ggg0
+       "bfi       r5,r6,#20,#12\n\t"     //r5 = hhhgggff
+
+       "stmia.w   %1,{r3,r4,r5}\n\t"
+       "add       %1,%1,#12\n\t"
+
+       "subs      %2,%2,#1\n\t"
+       "bne       1b"         
+       : "+r" (n4), "+r" (n5), "+r" (n6), "+r" (n7) :: "r3", "r4", "r5", "r6", "r7", "cc", "memory");
+
+  return (n7 * 12);
+}
+//
+__attribute__ ((always_inline)) static uint32_t pack8(uint8_t* input, uint8_t* output, uint32_t length) {
+  register uint32_t* n4 asm("r0") = (uint32_t*) input;
+  register uint32_t* n5 asm("r1") = (uint32_t*) output;
+  register uint32_t  n6 asm("r2") = length;
+  register uint32_t  n7 asm("r8");
+
+  asm volatile (
+       "lsr       %2,%2,#4\n\t"         //r2 = nLen >> 4 ; copy 16 bytes / pack 8 samples per loop
+       "mov       r8,%2\n\t"            //r8 = iLen
+       "1:\n\t"
+       "ldmia.w   %0,{r3,r4,r5,r6}\n\t" //r3 = 0bbb0aaa, r4 = 0ddd0ccc, r5 = 0fff0eee, r6 = 0hhh0ggg
+       "add       %0,%0,#16\n\t"
+
+       "ubfx      r7,r3,#20,#8\n\t"     //r7 = 000000bb
+       "ubfx      r3,r3,#4,#8\n\t"      //r3 = 000000aa
+       "orr       r3,r3,r7,lsl #8\n\t"  //r3 = 0000bbaa 
+       "ubfx      r7,r4,#4,#8\n\t"      //r7 = 000000cc
+       "orr       r3,r3,r7,lsl #16\n\t" //r3 = 00ccbbaa 
+       "ubfx      r7,r4,#20,#8\n\t"     //r7 = 000000dd
+       "orr       r3,r3,r7,lsl #24\n\t" //r3 = ddccbbaa 
+
+       "ubfx      r7,r5,#20,#8\n\t"     //r7 = 000000ff
+       "ubfx      r4,r5,#4,#8\n\t"      //r4 = 000000ee
+       "orr       r4,r4,r7,lsl #8\n\t"  //r4 = 0000ffee 
+       "ubfx      r7,r6,#4,#8\n\t"      //r7 = 000000gg
+       "orr       r4,r4,r7,lsl #16\n\t" //r4 = 00ggffee 
+       "ubfx      r7,r6,#20,#8\n\t"     //r7 = 000000hh
+       "orr       r4,r4,r7,lsl #24\n\t" //r4 = hhggffee 
+
+       "stmia.w   %1,{r3,r4}\n\t"
+       "add       %1,%1,#8\n\t"
+
+       "subs      %2,%2,#1\n\t"
+       "bne       1b"
+       : "+r" (n4), "+r" (n5), "+r" (n6), "+r" (n7) :: "r3", "r4", "r5", "r6", "r7", "cc", "memory");
+
+  return (n7 << 3);
+}
+//
+*/
 static __inline__ void clr_usb_buffer_offset(void)
 {
-  usb_bulk_buffer_offset_isr_m4 = 0;
-  usb_bulk_buffer_offset_main_m4 = 0;
+  adchs_dma_buffer_offset_isr_m4 = 0;
+  adchs_dma_buffer_offset_main_m4 = 0;
+  usb_dma_buffer_length_main_m4 = 0;
+  usb_dma_buffer_offset_main_m4 = 0;
+
   m0_queue->q_head = 0;
   m0_queue->q_tail = 0;
 /*
@@ -230,11 +446,7 @@ void adchs_start(uint8_t chan_num)
   led_on();
   LPC_ADCHS->TRIGGER = 1;
   __asm("dsb");
-/*
-#ifdef USE_PACKING
-  phase = 1;
-#endif
-*/
+
   /* Enable IRQ globally */
   __asm__("cpsie i");
 }
@@ -305,7 +517,7 @@ void dma_isr(void)
   {
     LPC_GPDMA->INTTCCLEAR = ADCHS_DMA_INT_CH; /* Clear Chan0 */
 
-    usb_bulk_buffer_offset_isr_m4 = (usb_bulk_buffer_offset_isr_m4 + ADCHS_DATA_TRANSFER_SIZE_BYTE) & USB_BULK_BUFFER_MASK;
+    adchs_dma_buffer_offset_isr_m4 = ((adchs_dma_buffer_offset_isr_m4 + ADCHS_DMA_TRANSFER_SIZE_BYTE) & ADCHS_DATA_BUFFER_SIZE_MASK); 
 /*
 #ifdef USE_PACKING
     set_usb_buffer_offset_m4( inc_mask_usb_buffer_offset_m4(get_usb_buffer_offset_m4(), 1) );    
@@ -446,31 +658,67 @@ int main(void)
 
   while(true)
   {
-    uint32_t buffer_offset, q_head, q_word;
+    uint32_t adchs_buffer_offset, usb_buffer_offset, usb_buffer_length, q_head, q_word;
     signal_wfe();
-    // If our local offset is different to the isr offset
-    if ((buffer_offset = usb_bulk_buffer_offset_main_m4) != usb_bulk_buffer_offset_isr_m4)
+    // If our local offset is different to the isr offset we have new samples to process
+    if ((adchs_buffer_offset = adchs_dma_buffer_offset_main_m4) != adchs_dma_buffer_offset_isr_m4)
     {
-#ifdef USE_PACKING
-      // pack 0x1000 12 bit samples into 0x0C00 16 bit words 
-      pack((uint16_t*) &usb_bulk_buffer[buffer_offset], (uint32_t*) &usb_bulk_buffer[buffer_offset], 0x1000);
-      q_word = ((buffer_offset << 16) | 0x1800);
-#else
-      q_word = ((buffer_offset << 16) | 0x2000);
-#endif
-      // Try to add the command to m0_queue 
-      q_head = (m0_queue->q_head & M0_QUEUE_MASK);
-      if ( (q_head + 1 - m0_queue->q_tail) & M0_QUEUE_MASK)
-      {// Tell the M0_USB core the offset and size of the data to send
-        m0_queue->q[q_head] = q_word;    
-        m0_queue->q_head = ((q_head + 1) & M0_QUEUE_MASK);
-        // Kick the M0_USB core to start the USB transfer
-        signal_sev();
-      } else {
-        // oops - M0 queue is full. Nothing we can do except silently discard
+      // Update our local pointer to the input data
+      adchs_dma_buffer_offset_main_m4 = ((adchs_buffer_offset + ADCHS_DATA_TRANSFER_SIZE_BYTE) & ADCHS_DATA_BUFFER_SIZE_MASK);
+
+      // get the pointers to the output buffer
+      usb_buffer_length = usb_dma_buffer_length_main_m4;
+      usb_buffer_offset = usb_dma_buffer_offset_main_m4 + usb_buffer_length;
+
+      q_word = 0;
+
+      // Pack the ADC samples in the user selected manner. Default to AIRSPY_FORMAT_PACK16
+      switch (airspy_format) 
+      {
+        case AIRSPY_FORMAT_PACK8:
+        {
+          usb_buffer_length += pack8(&adchs_dma_buffer[adchs_buffer_offset], &usb_bulk_buffer[usb_buffer_offset], ADCHS_DATA_TRANSFER_SIZE_BYTE);
+          break;
+        }
+        case AIRSPY_FORMAT_PACK12:
+        {
+          usb_buffer_length += pack12(&adchs_dma_buffer[adchs_buffer_offset], &usb_bulk_buffer[usb_buffer_offset], ADCHS_DATA_TRANSFER_SIZE_BYTE);
+          break;
+        }
+        case AIRSPY_FORMAT_PACK16:
+        default: 
+        {
+          usb_buffer_length += pack16(&adchs_dma_buffer[adchs_buffer_offset], &usb_bulk_buffer[usb_buffer_offset], ADCHS_DATA_TRANSFER_SIZE_BYTE);
+          break;
+        }
       }
-      // Update our local pointer to the data
-      usb_bulk_buffer_offset_main_m4 = ((buffer_offset + ADCHS_DATA_TRANSFER_SIZE_BYTE) & USB_BULK_BUFFER_MASK);
+
+      // If the output buffer is > than one-quarter full (but <= half-full) ...
+      // This ensures bulk_block outputs are between 0x1001 and 0x2000 bytes for best USB efficiency
+      if (usb_buffer_length > (USB_BULK_BUFFER_SIZE_BYTE >> 2)) {
+
+        // construct the queue word to pass to M0
+        q_word = (usb_dma_buffer_offset_main_m4 << 16) | usb_buffer_length;
+
+        // update the usb pouinters to point to the other half of the output buffer
+        usb_dma_buffer_length_main_m4 = 0;
+        usb_dma_buffer_offset_main_m4 = (usb_dma_buffer_offset_main_m4 + (USB_BULK_BUFFER_SIZE_BYTE >> 1)) & USB_BULK_BUFFER_SIZE_MASK;
+
+        // Try to add the command to m0_queue 
+        q_head = (m0_queue->q_head & M0_QUEUE_MASK);
+        if ( (q_head + 1 - m0_queue->q_tail) & M0_QUEUE_MASK)
+        {// Tell the M0_USB core the offset and size of the data to send
+          m0_queue->q[q_head] = q_word;    
+          m0_queue->q_head = ((q_head + 1) & M0_QUEUE_MASK);
+          // Kick the M0_USB core to start the USB transfer
+          signal_sev();
+        } else {
+          // oops - M0 queue is full. Nothing we can do except silently discard
+          //GPIO_NOT(PORT_EN_M0_ACTIVE) = PIN_EN_M0_ACTIVE;
+        }
+      } else {
+        usb_dma_buffer_length_main_m4 = usb_buffer_length;
+      }
     }
   }
 /*

--- a/airspy_m4/airspy_m4.c
+++ b/airspy_m4/airspy_m4.c
@@ -517,7 +517,7 @@ void dma_isr(void)
   {
     LPC_GPDMA->INTTCCLEAR = ADCHS_DMA_INT_CH; /* Clear Chan0 */
 
-    adchs_dma_buffer_offset_isr_m4 = ((adchs_dma_buffer_offset_isr_m4 + ADCHS_DMA_TRANSFER_SIZE_BYTE) & ADCHS_DATA_BUFFER_SIZE_MASK); 
+    adchs_dma_buffer_offset_isr_m4 = ((adchs_dma_buffer_offset_isr_m4 + ADCHS_DATA_TRANSFER_SIZE_BYTE) & ADCHS_DATA_BUFFER_SIZE_MASK); 
 /*
 #ifdef USE_PACKING
     set_usb_buffer_offset_m4( inc_mask_usb_buffer_offset_m4(get_usb_buffer_offset_m4(), 1) );    

--- a/common/airspy_conf.h
+++ b/common/airspy_conf.h
@@ -67,6 +67,18 @@ typedef struct
   uint8_t r820t_if_bw; /* from 0 to 63 */
 } airspy_m0_conf_t;
 
+//
+// M4 adds data to q[q_head]
+// M0 removes data from q[q_tail]
+//
+#define M0_QUEUE_SIZE (4)
+#define M0_QUEUE_MASK (M0_QUEUE_SIZE-1)
+typedef struct {
+  uint32_t q_head;
+  uint32_t q_tail;
+  uint32_t q[M0_QUEUE_SIZE];
+} airspy_m0_queue_t;
+
 /* Configuration for M4 core see airspy_conf_m4.c */
 extern const airspy_sys_clock_t airspy_m4_init_conf;
 extern const airspy_sys_samplerate_t airspy_m4_conf[AIRSPY_CONF_NB];


### PR DESCRIPTION
Remove the current phase code.

Implement a queue so that M4 can post messages into the queue and M0 can
pull the messages out. The messages encode a buffer offset and length.
This allows M4 to tell M0 to transmit X bytes from offset Y over the USB
bus.

The advantage of this is that the M0 code can be common for all
byte/word packing carried out by M4. Also up to 3 commands can be queued
allowing M0 to catch up if it is slow to transmit over the USB.
