### PR TITLE
Writing to read only ADCHS registers

### DIFF
--- a/airspy_m4/adchs.c
+++ b/airspy_m4/adchs.c
@@ -187,8 +187,10 @@ void ADCHS_init(void)
   LPC_ADCHS->THR_B = 0x00FFF000;
 
   /* Configure Interrupt 0 & 1 Enable register to default value (even if not used) */
-  LPC_ADCHS->MASK0 = 0x00000000;
-  LPC_ADCHS->MASK1 = 0x00000000;
+  LPC_ADCHS->CLR_EN0   = STATUS0_CLEAR_MASK;
+  LPC_ADCHS->CLR_STAT0 = STATUS0_CLEAR_MASK;
+  LPC_ADCHS->CLR_EN1   = STATUS1_CLEAR_MASK;
+  LPC_ADCHS->CLR_STAT1 = STATUS1_CLEAR_MASK;
 
 }
 


### PR DESCRIPTION
I think lines 190 & 191 of adchs are wrong because page 1330 of UM10503
Rev1.9 indicates MASK0 and MASK1 are read only status registers. These
modifications clear the registers correctly.
